### PR TITLE
Improve error handling for missing files

### DIFF
--- a/script_folder/gene_counting_paired.py
+++ b/script_folder/gene_counting_paired.py
@@ -93,6 +93,9 @@ def EasySci_count(input_folder, output_folder, exons, genes, gene_end, gene_anno
     if not os.path.exists(input_file_name):
         print(f"ERROR: alignment file {input_file_name} not found")
         return 1
+    if os.path.getsize(input_file_name) == 0:
+        print(f"WARNING: {input_file_name} is empty, skipping")
+        return 1
     try:
         almnt_file = HTSeq.SAM_Reader(input_file_name)
     except Exception as e:

--- a/script_folder/gene_counting_single.py
+++ b/script_folder/gene_counting_single.py
@@ -93,6 +93,9 @@ def EasySci_count(input_folder, output_folder, exons, genes, gene_end, gene_anno
     if not os.path.exists(input_file_name):
         print(f"ERROR: alignment file {input_file_name} not found")
         return 1
+    if os.path.getsize(input_file_name) == 0:
+        print(f"WARNING: {input_file_name} is empty, skipping")
+        return 1
     try:
         almnt_file = HTSeq.SAM_Reader(input_file_name)
     except Exception as e:

--- a/script_folder/post_processing_genes.py
+++ b/script_folder/post_processing_genes.py
@@ -2,6 +2,7 @@
 This post processing script takes the output of the gene counting, merges the PCR batches and the random hexamer and shortdT reads from the same cells, and formats and saves the final output files.
 '''
 import sys
+import os
 import pandas as pd
 import numpy as np
 import scipy.sparse as sp
@@ -25,8 +26,13 @@ def merge_gene_count_files(input_folder, output_folder, sampleID, RT_matching_fi
     ## Open and merge the PCR batches
     for i, sample in enumerate(sample_list):
         cell_annotation_file = input_folder + sample + "_cell_annotate.csv"
-        cell_annotation = pd.read_csv(cell_annotation_file, header=None)
         count_matrix_file = input_folder + sample + ".count"
+
+        if not (os.path.exists(cell_annotation_file) and os.path.exists(count_matrix_file)):
+            print(f"Warning: missing gene count files for {sample}, skipping this sample")
+            continue
+
+        cell_annotation = pd.read_csv(cell_annotation_file, header=None)
         count_matrix = np.genfromtxt(count_matrix_file, delimiter=',')
         sparse_matrix = sp.coo_matrix((count_matrix[:,2], ((count_matrix[:,0] - 1 ), (count_matrix[:,1] - 1))), shape=(gene_annotation.shape[0], cell_annotation.shape[0]), dtype=int)
         


### PR DESCRIPTION
## Summary
- handle empty alignment files during gene counting
- skip missing gene count files in post processing

## Testing
- `python -m py_compile script_folder/post_processing_genes.py script_folder/gene_counting_single.py script_folder/gene_counting_paired.py`

------
https://chatgpt.com/codex/tasks/task_e_687e1047cf84832ca7328d007c977d7c